### PR TITLE
Update @papb/zip to v3.0.0 & remove unwanted dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const tiny = require('tiny-json-http')
 const https = require('https')
 const fs = require('fs')
 const fse = require('fs-extra')
-const { zipContents, unzip } = require('@papb/zip')
+const { zipDirContents, unzip } = require('@papb/zip')
 const path = require('path')
 const crypto = require('crypto')
 
@@ -353,7 +353,7 @@ function zipResourcePack(resourcepackPath, newFilepath)
     {
       fs.unlinkSync(newFilepath)
     }
-    await zipContents(resourcepackPath, path.basename(newFilepath))
+    await zipDirContents(resourcepackPath, path.basename(newFilepath))
     resolve()
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,11 +130,6 @@
         "pend": "~1.2.0"
       }
     },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
-    },
     "fs-extra": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
@@ -186,11 +181,6 @@
         "is-stream": "^2.0.0",
         "type-fest": "^0.8.0"
       }
-    },
-    "https": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
-      "integrity": "sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q="
     },
     "indent-string": {
       "version": "4.0.0",
@@ -277,15 +267,6 @@
         "aggregate-error": "^3.0.0"
       }
     },
-    "path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "requires": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -295,11 +276,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -411,21 +387,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        }
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@papb/zip": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@papb/zip/-/zip-2.0.6.tgz",
-      "integrity": "sha512-LtUN83WkMhcXuZ/1luKT/Lr75SysZ99+x7qh5zQKCpp5bvNi2Mebvm57FVEMFsZv0HpIdMN6rlF+8ZqJMltErg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@papb/zip/-/zip-3.0.0.tgz",
+      "integrity": "sha512-KL3mBNyd4GwgDrnwURp6PLy/YDPQ3e1KJVFPg3XL7/0ZacLGQSI5WcJSrCOrsjCewZOJ2+Ch5eMXbu2Y3HJvNQ==",
       "requires": {
         "extract-zip": "1.7.0",
         "fs-jetpack": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@papb/zip": "^3.0.0",
-    "fs": "0.0.1-security",
     "fs-extra": "^9.0.1",
-    "https": "^1.0.0",
-    "path": "^0.12.7",
     "tempy": "^0.6.0",
     "tiny-json-http": "^7.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@papb/zip": "^2.0.6",
+    "@papb/zip": "^3.0.0",
     "fs": "0.0.1-security",
     "fs-extra": "^9.0.1",
     "https": "^1.0.0",


### PR DESCRIPTION
Hello! Thank you for using my `@papb/zip` package.

This pull request updates it to the newest version (`v3.0.0`) accounting for the breaking change.

**Edit:** While performing this update, I noticed that you have `fs`, `https` and `path` as dependencies listed in your `package.json`. This is a mistake; these three packages are available by default with any version of NodeJS. In fact, you ended up replacing the native ones with custom packages... Definitely not what you want. Luckily [`fs`](https://www.npmjs.com/package/fs) is kept as a security placeholder by the NPM team, so there is probably no issue with it. But [`https`](https://www.npmjs.com/package/https) for example, does not even have a readme... You can just remove them and use the native ones.